### PR TITLE
move devDependencies to devDependencies so security checks don't fall

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,13 +7,15 @@
     "build": "gulp"
   },
   "dependencies": {
+    "in-view": "^0.6.1",
+    "shortid": "^2.2.6"
+  },
+  "devDependencies": {
     "browserify": "^16.2.2",
     "gulp": "^3.9.1",
     "gulp-sourcemaps": "^2.6.4",
     "gulp-uglify": "^3.0.0",
     "gulp-util": "^3.0.8",
-    "in-view": "^0.6.1",
-    "shortid": "^2.2.6",
     "vinyl-buffer": "^1.0.1",
     "vinyl-source-stream": "^2.0.0"
   },


### PR DESCRIPTION
move devDependencies to devDepencies so security checks don't fall over all the security errors that are present in the devDependencies right now.

https://app.snyk.io/test/npm/vueinview/1.0.5